### PR TITLE
feat: Configure package.json for GitHub Packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "callback-to-promises",
+  "name": "@guljarpd/callback-to-promises",
   "version": "1.0.3",
   "description": "Convert your callback function into promise",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -21,5 +21,8 @@
   "bugs": {
     "url": "https://github.com/guljarpd/callbackToPromise/issues"
   },
-  "homepage": "https://github.com/guljarpd/callbackToPromise#readme"
+  "homepage": "https://github.com/guljarpd/callbackToPromise#readme",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  }
 }


### PR DESCRIPTION
- Updated package name to be scoped: `@guljarpd/callback-to-promises`.
- Added `publishConfig` to point to the GitHub Packages registry.
- Ensured repository, bugs, and homepage URLs are correctly set.